### PR TITLE
Fix package generation

### DIFF
--- a/pack/Dockerfile
+++ b/pack/Dockerfile
@@ -3,8 +3,8 @@ FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
 RUN dotnet tool install -g dotnet-grpc
 ENV PATH="${PATH}:/root/.dotnet/tools"
 
-COPY Directory.Build.props .
-COPY entrypoint.sh .
-RUN chmod +x /entrypoint.sh
+COPY Directory.Build.props /opt/build-tools/Directory.Build.props
+COPY entrypoint.sh /bin/entrypoint.sh
+RUN chmod +x /bin/entrypoint.sh
 
-ENTRYPOINT [ "/entrypoint.sh"]
+ENTRYPOINT [ "/bin/entrypoint.sh"]

--- a/pack/entrypoint.sh
+++ b/pack/entrypoint.sh
@@ -41,14 +41,21 @@ echo "  - Output path     = $OUTPUT_PATH"
 echo "  - Company         = $COMPANY"
 echo "  - Authors         = $AUTHORS"
 
+export PATH="$PATH:/root/.dotnet/tools"
+
 echo "Clean up..."
 rm -rf ./src
 
+echo "Installing GRPC tools"
+export PATH="$PATH:/root/.dotnet/tools"
+dotnet tool install --global dotnet-grpc-cli --version 0.5.0
+
 echo "Creating file 'Directory.Build.props'..."
-sed -i -e 's/{{ Company }}/$COMPANY/g' -e 's/{{ Authors }}/$AUTHORS/g'  Directory.Build.props
+cp /opt/build-tools/Directory.Build.props ./Directory.Build.props
+sed -i -e "s/{{ Company }}/$COMPANY/g" -e "s/{{ Authors }}/$AUTHORS/g"  Directory.Build.props
 
 echo "Creating $PACKAGE_NAME project..."
-dotnet new classlib --name $PACKAGE_NAME --output $SRC/$PACKAGE_NAME --framework netstandard2.0 
+dotnet new classlib --name $PACKAGE_NAME --output $SRC/$PACKAGE_NAME --framework netstandard2.0
 rm -f ./$SRC/$PACKAGE_NAME/Class1.cs
 
 echo "Adding Protobuf files..."
@@ -63,8 +70,8 @@ if [ "$found" = "found" ]; then
   done
 
   echo "Packing $PACKAGE_NAME version $PACKAGE_VERSION at $OUTPUT_PATH"...
-  dotnet pack ./$SRC/$PACKAGE_NAME/$PACKAGE_NAME.csproj -c Release -p:PackageVersion=$PACKAGE_VERSION -o $OUTPUT_PATH 
+  dotnet pack ./$SRC/$PACKAGE_NAME/$PACKAGE_NAME.csproj -c Release -p:PackageVersion=$PACKAGE_VERSION -o $OUTPUT_PATH
 else
   echo "Error: No Protobuf file found at '$PROTOBUF_FOLDER'"
   exit -1
-fi  
+fi


### PR DESCRIPTION
Fix a number of problems:

- Store `Directory.Build.props` in a folder and NOT in root because otherwise .NET finds it while traversing hierarchy
- Fix quotations in `sed`: single quotes don't expand env variables
- Install `dotnet-grpc` tools explicitly