### PR TITLE
Remove incorrect message when adding proto files

### DIFF
--- a/pack/entrypoint.sh
+++ b/pack/entrypoint.sh
@@ -67,7 +67,6 @@ if [ "$found" = "found" ]; then
   for file in $(find $PROTOBUF_FOLDER -name "*.proto")
   do
       path="../.$file"
-      echo "Creating $PACKAGE_NAME solution..."
       dotnet-grpc add-file  --services None --project ./$SRC/$PACKAGE_NAME/$PACKAGE_NAME.csproj  $path
   done
 


### PR DESCRIPTION
A message relating to creating a solution is being printed in the output, but the actual action taken is adding proto files to the project:

```
Creating EP.Certificate.Generation.Contract solution...
Adding required gRPC package reference: Google.Protobuf.
Adding required gRPC package reference: Grpc.Tools.
Adding file reference ../../protos/ep/certificate_generation/events/teacher_certification_certificate_requested.proto.
Creating EP.Certificate.Generation.Contract solution...
Adding file reference ../../protos/ep/certificate_generation/events/competition_certificates_requested.proto.
Creating EP.Certificate.Generation.Contract solution...
Adding file reference ../../protos/ep/certificate_generation/events/certificate_generation_completed.proto.
```

Changing the message to indicate it's adding the files would be redundant seeing as it's printing a message anyway, so I have simply removed it.